### PR TITLE
chore: upgrade RDS engine versions (1 resources)

### DIFF
--- a/rds-with-proxy.yaml
+++ b/rds-with-proxy.yaml
@@ -12,7 +12,7 @@ Mappings:
   ClusterSettings:
     global:
       dbSchema: mylab
-      dbVersion: 5.7.mysql_aurora.2.09.1
+      dbVersion: 8.0.mysql_aurora.3.10.0
       dbEngine: aurora-mysql
       dbFamily: aurora-mysql5.7
       port: 3306


### PR DESCRIPTION
# RDS Engine Version Upgrades

## Summary
This PR contains automated upgrades for 1 RDS resources across 1 files.

## Changes
- **Mapping for dbCluster**: 5.7.mysql_aurora.2.09.1 → 8.0.mysql_aurora.3.10.0

## Review Checklist
- [ ] Review version compatibility
- [ ] Check for breaking changes
- [ ] Verify backup procedures
- [ ] Test in staging environment

*This PR was generated automatically by the RDS Upgrade Automation tool.*
