### PR TITLE
chore: upgrade RDS engine versions (2 resources)

### DIFF
--- a/rds-with-proxy.yaml
+++ b/rds-with-proxy.yaml
@@ -12,9 +12,9 @@ Mappings:
   ClusterSettings:
     global:
       dbSchema: mylab
-      dbVersion: 5.7.mysql_aurora.2.09.1
+      dbVersion: 8.0.mysql_aurora.3.10.0
       dbEngine: aurora-mysql
-      dbFamily: aurora-mysql5.7
+      dbFamily: aurora-mysql8.0
       port: 3306
       nodeType: db.r5.large
 


### PR DESCRIPTION
# RDS Engine Version Upgrades

## Summary
This PR contains automated upgrades for 2 RDS resources across 1 files.

## Changes
- **Mapping for dbCluster**: 5.7.mysql_aurora.2.10.1 → 8.0.mysql_aurora.3.10.0
- **Mapping for dbCluster (dbFamily)**: aurora-mysql5.7 → aurora-mysql8.0

## Review Checklist
- [ ] Review version compatibility
- [ ] Check for breaking changes
- [ ] Verify backup procedures
- [ ] Test in staging environment

*This PR was generated automatically by the RDS Upgrade Automation tool.*
